### PR TITLE
Serialize Infinity and -Infinity correctly

### DIFF
--- a/src/json.rs
+++ b/src/json.rs
@@ -1004,7 +1004,15 @@ impl Display for Json {
                 let arg = from_utf8(&bytes[..*len]).unwrap();
                 write!(f, "{}", arg)
             }
-            Float(Floating::Data { value: v }) => write!(f, "{:e}", v),
+            Float(Floating::Data { value: v }) => {
+                if *v == f64::INFINITY {
+                    write!(f, "Infinity")
+                } else if *v == f64::NEG_INFINITY {
+                    write!(f, "-Infinity")
+                } else {
+                    write!(f, "{:e}", v)
+                }
+            },
             S(val) => {
                 encode_string(f, val)?;
                 Ok(())

--- a/src/json_qc.rs
+++ b/src/json_qc.rs
@@ -75,7 +75,15 @@ impl Display for JsonQC {
             JsonQC::Bool(true) => write!(f, "true"),
             JsonQC::Bool(false) => write!(f, "false"),
             JsonQC::Integer(val) => write!(f, "{}", val),
-            JsonQC::Float(val) => write!(f, "{:e}", val),
+            JsonQC::Float(val) => {
+                if *val == f64::INFINITY {
+                    write!(f, "Infinity")
+                } else if *val == f64::NEG_INFINITY {
+                    write!(f, "-Infinity")
+                } else {
+                    write!(f, "{:e}", val)
+                }
+            },
             JsonQC::String(val) => json::encode_string(f, &val)
             JsonQC::Array(val) => {
                 if val.len() == 0 {


### PR DESCRIPTION
Letting Rust format them results in the invalid 'inf' and '-inf', so they require special handling.

Fixes #19